### PR TITLE
Simplifying functions with ncol/nrow params (#408)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ spiceypy/utils/__pycache__/
 *.whl
 .pytest_cache/
 *.sqlite3
+/badhashkernel.txt

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -21,11 +21,13 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
+import warnings
 from contextlib import contextmanager
 from datetime import datetime, timezone
 import functools
 import ctypes
 from typing import Callable, Iterator, Iterable, Optional, Tuple, Union, Sequence
+
 
 import numpy
 from numpy import ndarray, str_
@@ -68,11 +70,24 @@ from .utils.support_types import (
 __author__ = "AndrewAnnex"
 
 ################################################################################
+OptionalInt = Optional[int]
 
 _default_len_out = 256
 
 _SPICE_EK_MAXQSEL = 100  # Twice the 50 in gcc-linux-64
 _SPICE_EK_EKRCEX_ROOM_DEFAULT = 100  # Enough?
+
+
+def warn_depricated_args(**kwargs) -> None:
+    keys = list(kwargs.keys())
+    values = list(kwargs.values())
+    if any(values):
+        varnames = ", ".join(keys)
+        warnings.warn(
+            f"Specifying any of: {varnames} will be deprecated as of SpiceyPy 5.0.0",
+            DeprecationWarning,
+        )
+    pass
 
 
 def check_for_spice_error(f: Optional[Callable]) -> None:
@@ -681,7 +696,7 @@ def bschoc(
     ndim: int,
     lenvals: int,
     array: Union[ndarray, Iterable[str]],
-    order: Iterable[int],
+    order: Union[ndarray, Iterable[int]],
 ) -> int:
     """
     Do a binary search for a given value within a character string array,
@@ -706,7 +721,12 @@ def bschoc(
 
 
 @spice_error_check
-def bschoi(value: int, ndim: int, array: Iterable[int], order: Iterable[int]) -> int:
+def bschoi(
+    value: int,
+    ndim: int,
+    array: Union[ndarray, Iterable[int]],
+    order: Union[ndarray, Iterable[int]],
+) -> int:
     """
     Do a binary search for a given value within an integer array,
     accompanied by an order vector.  Return the index of the
@@ -852,7 +872,7 @@ def ccifrm(
 
 @spice_error_check
 def cgv2el(
-    center: Iterable[float],
+    center: Union[ndarray, Iterable[float]],
     vec1: Union[ndarray, Iterable[float]],
     vec2: Union[ndarray, Iterable[float]],
 ) -> Ellipse:
@@ -876,7 +896,11 @@ def cgv2el(
 
 @spice_error_check
 def chbder(
-    cp: Iterable[float], degp: int, x2s: Iterable[float], x: float, nderiv: int
+    cp: Union[ndarray, Iterable[float]],
+    degp: int,
+    x2s: Union[ndarray, Iterable[float]],
+    x: float,
+    nderiv: int,
 ) -> ndarray:
     """
     Given the coefficients for the Chebyshev expansion of a
@@ -1234,7 +1258,7 @@ def ckw02(
     stop: ndarray,
     quats: ndarray,
     avvs: ndarray,
-    rates: Iterable[float],
+    rates: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write a type 2 segment to a C-kernel.
@@ -1285,7 +1309,7 @@ def ckw03(
     quats: ndarray,
     avvs: ndarray,
     nints: int,
-    starts: Iterable[float],
+    starts: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Add a type 3 segment to a C-kernel.
@@ -2408,7 +2432,9 @@ def dgeodr(x: float, y: float, z: float, re: float, f: float) -> ndarray:
 
 
 @spice_error_check
-def diags2(symmat: Iterable[Iterable[float]]) -> Tuple[ndarray, ndarray]:
+def diags2(
+    symmat: Union[ndarray, Iterable[Iterable[float]]]
+) -> Tuple[ndarray, ndarray]:
     """
     Diagonalize a symmetric 2x2 matrix.
 
@@ -3721,7 +3747,7 @@ def ekaced(
     recno: int,
     column: str,
     nvals: int,
-    dvals: Iterable[float],
+    dvals: Union[ndarray, Iterable[float]],
     isnull: bool,
 ) -> None:
     """
@@ -3754,7 +3780,7 @@ def ekacei(
     recno: int,
     column: str,
     nvals: int,
-    ivals: Iterable[int],
+    ivals: Union[ndarray, Iterable[int]],
     isnull: bool,
 ) -> None:
     """
@@ -3787,10 +3813,10 @@ def ekaclc(
     column: str,
     vallen: int,
     cvals: Iterable[str],
-    entszs: Iterable[int],
+    entszs: Union[ndarray, Iterable[int]],
     nlflgs: Iterable[bool],
     rcptrs: ndarray,
-    wkindx: Iterable[int],
+    wkindx: Union[ndarray, Iterable[int]],
 ) -> ndarray:
     """
     Add an entire character column to an EK segment.
@@ -3828,11 +3854,11 @@ def ekacld(
     handle: int,
     segno: int,
     column: str,
-    dvals: Iterable[float],
-    entszs: Iterable[int],
+    dvals: Union[ndarray, Iterable[float]],
+    entszs: Union[ndarray, Iterable[int]],
     nlflgs: Iterable[bool],
     rcptrs: ndarray,
-    wkindx: Iterable[int],
+    wkindx: Union[ndarray, Iterable[int]],
 ) -> ndarray:
     """
     Add an entire double precision column to an EK segment.
@@ -3866,11 +3892,11 @@ def ekacli(
     handle: int,
     segno: int,
     column: str,
-    ivals: Iterable[int],
-    entszs: Iterable[int],
+    ivals: Union[ndarray, Iterable[int]],
+    entszs: Union[ndarray, Iterable[int]],
     nlflgs: Iterable[bool],
     rcptrs: ndarray,
-    wkindx: Iterable[int],
+    wkindx: Union[ndarray, Iterable[int]],
 ) -> ndarray:
     """
     Add an entire integer column to an EK segment.
@@ -4633,7 +4659,7 @@ def ekuced(
     recno: int,
     column: str,
     nvals: int,
-    dvals: Iterable[float],
+    dvals: Union[ndarray, Iterable[float]],
     isnull: bool,
 ) -> None:
     """
@@ -4666,7 +4692,7 @@ def ekucei(
     recno: int,
     column: str,
     nvals: int,
-    ivals: Iterable[int],
+    ivals: Union[ndarray, Iterable[int]],
     isnull: bool,
 ) -> None:
     """
@@ -5225,7 +5251,7 @@ def fn2lun(fname: str) -> int:
 @spice_error_check
 def fovray(
     inst: str,
-    raydir: Iterable[float],
+    raydir: Union[ndarray, Iterable[float]],
     rframe: str,
     abcorr: str,
     observer: str,
@@ -5305,7 +5331,7 @@ def fovtrg(
 
 
 @spice_error_check
-def frame(x: Iterable[float]) -> Tuple[ndarray, ndarray, ndarray]:
+def frame(x: Union[ndarray, Iterable[float]]) -> Tuple[ndarray, ndarray, ndarray]:
     """
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/frame_c.html
 
@@ -5695,9 +5721,9 @@ def gfevnt(
     lenvals: int,
     qpnams: Iterable[str],
     qcpars: Iterable[str],
-    qdpars: Iterable[float],
-    qipars: Iterable[int],
-    qlpars: Iterable[int],
+    qdpars: Union[ndarray, Iterable[float]],
+    qipars: Union[ndarray, Iterable[int]],
+    qlpars: Union[ndarray, Iterable[int]],
     op: str,
     refval: float,
     tol: float,
@@ -5796,7 +5822,7 @@ def gfevnt(
 def gffove(
     inst: str,
     tshape: str,
-    raydir: Iterable[float],
+    raydir: Union[ndarray, Iterable[float]],
     target: str,
     tframe: str,
     abcorr: str,
@@ -5889,7 +5915,7 @@ def gfilum(
     fixref: str,
     abcorr: str,
     obsrvr: str,
-    spoint: Iterable[float],
+    spoint: Union[ndarray, Iterable[float]],
     relate: str,
     refval: float,
     adjust: float,
@@ -6554,7 +6580,7 @@ def gfsntc(
     abcorr: str,
     obsrvr: str,
     dref: str,
-    dvec: Iterable[float],
+    dvec: Union[ndarray, Iterable[float]],
     crdsys: str,
     coord: str,
     relate: str,
@@ -7578,7 +7604,7 @@ def irftrn(refa: str, refb: str) -> ndarray:
 
 
 @spice_error_check
-def isordv(array: Iterable[int], n: int) -> bool:
+def isordv(array: Union[ndarray, Iterable[int]], n: int) -> bool:
     """
     Determine whether an array of n items contains the integers
     0 through n-1.
@@ -7621,7 +7647,7 @@ def isrchc(value: str, ndim: int, lenvals: int, array: Iterable[str]) -> int:
 
 
 @spice_error_check
-def isrchd(value: float, ndim: int, array: Iterable[float]) -> int:
+def isrchd(value: float, ndim: int, array: Union[ndarray, Iterable[float]]) -> int:
     """
     Search for a given value within a double precision array. Return
     the index of the first matching array entry, or -1 if the key value
@@ -7643,7 +7669,7 @@ def isrchd(value: float, ndim: int, array: Iterable[float]) -> int:
 
 
 @spice_error_check
-def isrchi(value: int, ndim: int, array: Iterable[int]) -> int:
+def isrchi(value: int, ndim: int, array: Union[ndarray, Iterable[int]]) -> int:
     """
     Search for a given value within an integer array. Return
     the index of the first matching array entry, or -1 if the key
@@ -8158,7 +8184,7 @@ def limbpt(
     abcorr: str,
     corloc: str,
     obsrvr: str,
-    refvec: Iterable[float],
+    refvec: Union[ndarray, Iterable[float]],
     rolstp: float,
     ncuts: int,
     schstp: float,
@@ -8396,7 +8422,7 @@ def lstlec(string: str, n: int, lenvals: int, array: Iterable[str]) -> int:
 
 
 @spice_error_check
-def lstled(x: float, n: int, array: Iterable[float]) -> int:
+def lstled(x: float, n: int, array: Union[ndarray, Iterable[float]]) -> int:
     """
     Given a number x and an array of non-decreasing floats
     find the index of the largest array element less than or equal to x.
@@ -8415,7 +8441,7 @@ def lstled(x: float, n: int, array: Iterable[float]) -> int:
 
 
 @spice_error_check
-def lstlei(x: int, n: int, array: Iterable[int]) -> int:
+def lstlei(x: int, n: int, array: Union[ndarray, Iterable[int]]) -> int:
     """
     Given a number x and an array of non-decreasing ints,
     find the index of the largest array element less than or equal to x.
@@ -8458,7 +8484,7 @@ def lstltc(string: str, n: int, lenvals: int, array: Iterable[str]) -> int:
 
 
 @spice_error_check
-def lstltd(x: float, n: int, array: Iterable[float]) -> int:
+def lstltd(x: float, n: int, array: Union[ndarray, Iterable[float]]) -> int:
     """
     Given a number x and an array of non-decreasing floats
     find the index of the largest array element less than x.
@@ -8477,7 +8503,7 @@ def lstltd(x: float, n: int, array: Iterable[float]) -> int:
 
 
 @spice_error_check
-def lstlti(x: int, n: int, array: Iterable[int]) -> int:
+def lstlti(x: int, n: int, array: Union[ndarray, Iterable[int]]) -> int:
     """
     Given a number x and an array of non-decreasing int,
     find the index of the largest array element less than x.
@@ -8630,7 +8656,7 @@ def lxqstr(string: str, qchar: str, first: int) -> Tuple[int, int]:
 
 @spice_error_check
 def m2eul(
-    r: Iterable[Iterable[float]], axis3: int, axis2: int, axis1: int
+    r: Union[ndarray, Iterable[Iterable[float]]], axis3: int, axis2: int, axis1: int
 ) -> Tuple[float, float, float]:
     """
     Factor a rotation matrix as a product of three rotations
@@ -8792,20 +8818,29 @@ def mtxm(m1: ndarray, m2: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mtxmg(m1: ndarray, m2: ndarray, ncol1: int, nr1r2: int, ncol2: int) -> ndarray:
+def mtxmg(
+    m1: ndarray,
+    m2: ndarray,
+    ncol1: OptionalInt = None,
+    nr1r2: OptionalInt = None,
+    ncol2: OptionalInt = None,
+) -> ndarray:
     """
     Multiply the transpose of a matrix with
     another matrix, both of arbitrary size.
 
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/mtxmg_c.html
 
-    :param m1: nr1r2 X ncol1 double precision matrix.
-    :param m2: nr1r2 X ncol2 double precision matrix.
+    :param m1: N x M double precision matrix.
+    :param m2: N x O double precision matrix.
     :param ncol1: Column dimension of m1 and row dimension of mout.
     :param nr1r2: Row dimension of m1 and m2.
     :param ncol2: Column dimension of m2.
-    :return: Transpose of m1 times m2.
+    :return: Transpose of m1 times m2 (O x M).
     """
+    warn_depricated_args(ncol1=ncol1, nr1r2=nr1r2, ncol2=ncol2)
+    ncol1, ncol2 = len(m1[0]), len(m2[0])
+    nr1r2 = len(m1)
     m1 = stypes.to_double_matrix(m1)
     m2 = stypes.to_double_matrix(m2)
     mout = stypes.empty_double_matrix(x=ncol2, y=ncol1)
@@ -8836,7 +8871,9 @@ def mtxv(m1: ndarray, vin: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
+def mtxvg(
+    m1: ndarray, v2: ndarray, ncol1: OptionalInt = None, nr1r2: OptionalInt = None
+) -> ndarray:
     """
     Multiply the transpose of a matrix and
     a vector of arbitrary size.
@@ -8849,6 +8886,9 @@ def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
     :param nr1r2: Row dimension of m1 and length of v2.
     :return: Product vector m1 transpose * v2.
     """
+    warn_depricated_args(ncol1=ncol1, nr1r2=nr1r2)
+    ncol1 = len(m1[0])
+    nr1r2 = len(v2)
     m1 = stypes.to_double_matrix(m1)
     v2 = stypes.to_double_vector(v2)
     ncol1 = ctypes.c_int(ncol1)
@@ -8859,7 +8899,10 @@ def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
 
 
 @spice_error_check
-def mxm(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarray:
+def mxm(
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
+) -> ndarray:
     """
     Multiply two 3x3 matrices.
 
@@ -8878,11 +8921,11 @@ def mxm(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarray
 
 @spice_error_check
 def mxmg(
-    m1: Iterable[Iterable[float]],
-    m2: Iterable[Iterable[float]],
-    nrow1: int,
-    ncol1: int,
-    ncol2: int,
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
+    nrow1: OptionalInt = None,
+    ncol1: OptionalInt = None,
+    ncol2: OptionalInt = None,
 ) -> ndarray:
     """
     Multiply two double precision matrices of arbitrary size.
@@ -8896,6 +8939,8 @@ def mxmg(
     :param ncol2: Column dimension of m2
     :return: nrow1 X ncol2 double precision matrix.
     """
+    warn_depricated_args(nrow1=nrow1, ncol1=ncol1, ncol2=ncol2)
+    nrow1, ncol1, ncol2 = len(m1), len(m1[0]), len(m2[0])
     m1 = stypes.to_double_matrix(m1)
     m2 = stypes.to_double_matrix(m2)
     mout = stypes.empty_double_matrix(x=ncol2, y=nrow1)
@@ -8907,7 +8952,10 @@ def mxmg(
 
 
 @spice_error_check
-def mxmt(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarray:
+def mxmt(
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
+) -> ndarray:
     """
     Multiply a 3x3 matrix and the transpose of another 3x3 matrix.
 
@@ -8925,7 +8973,7 @@ def mxmt(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarra
 
 
 @spice_error_check
-def mxmtg(m1: ndarray, m2: ndarray, nrow1: int, nc1c2: int, nrow2: int) -> ndarray:
+def mxmtg(m1: Union[ndarray, Iterable[Iterable[float]]], m2: Union[ndarray, Iterable[Iterable[float]]], nrow1: OptionalInt = None, nc1c2: OptionalInt = None, nrow2: OptionalInt = None) -> ndarray:
     """
     Multiply a matrix and the transpose of a matrix, both of arbitrary size.
 
@@ -8938,6 +8986,8 @@ def mxmtg(m1: ndarray, m2: ndarray, nrow1: int, nc1c2: int, nrow2: int) -> ndarr
     :param nrow2: Row dimension of m2 and column dimension of mout.
     :return: Product matrix.
     """
+    warn_depricated_args(nrow1=nrow1, nc1c2=nc1c2, nrow2=nrow2)
+    nrow1, nc1c2, nrow2 = len(m1), len(m1[0]), len(m2)
     m1 = stypes.to_double_matrix(m1)
     m2 = stypes.to_double_matrix(m2)
     mout = stypes.empty_double_matrix(x=nrow2, y=nrow1)
@@ -8968,7 +9018,7 @@ def mxv(m1: ndarray, vin: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mxvg(m1: ndarray, v2: ndarray, nrow1: int, nc1r2: int) -> ndarray:
+def mxvg(m1: Union[ndarray, Iterable[Iterable[float]]], v2: Union[ndarray, Iterable[Iterable[float]]], nrow1: OptionalInt = None, nc1r2: OptionalInt = None) -> ndarray:
     """
     Multiply a matrix and a vector of arbitrary size.
 
@@ -8980,6 +9030,8 @@ def mxvg(m1: ndarray, v2: ndarray, nrow1: int, nc1r2: int) -> ndarray:
     :param nc1r2: Column dimension of m1 and length of v2.
     :return: Product vector m1*v2
     """
+    warn_depricated_args(nrow1=nrow1, nc1r2=nc1r2)
+    nrow1, nc1r2 = len(m1), len(m1[0])
     m1 = stypes.to_double_matrix(m1)
     v2 = stypes.to_double_vector(v2)
     nrow1 = ctypes.c_int(nrow1)
@@ -9051,7 +9103,7 @@ def ncposr(string: str, chars: str, start: int) -> int:
 
 @spice_error_check
 def nearpt(
-    positn: Iterable[float], a: float, b: float, c: float
+    positn: Union[ndarray, Iterable[float]], a: float, b: float, c: float
 ) -> Tuple[ndarray, float]:
     """
     locates the point on the surface of an ellipsoid that is nearest to a
@@ -9080,7 +9132,11 @@ def nearpt(
 
 @spice_error_check
 def npedln(
-    a: float, b: float, c: float, linept: Iterable[float], linedr: Iterable[float]
+    a: float,
+    b: float,
+    c: float,
+    linept: Union[ndarray, Iterable[float]],
+    linedr: Union[ndarray, Iterable[float]],
 ) -> Tuple[ndarray, float]:
     """
     Find nearest point on a triaxial ellipsoid to a specified
@@ -9107,7 +9163,9 @@ def npedln(
 
 
 @spice_error_check
-def npelpt(point: Iterable[float], ellips: Ellipse) -> Tuple[ndarray, float]:
+def npelpt(
+    point: Union[ndarray, Iterable[float]], ellips: Ellipse
+) -> Tuple[ndarray, float]:
     """
     Find the nearest point on an ellipse to a specified point, both
     in three-dimensional space, and find the distance between the
@@ -9128,7 +9186,9 @@ def npelpt(point: Iterable[float], ellips: Ellipse) -> Tuple[ndarray, float]:
 
 @spice_error_check
 def nplnpt(
-    linpt: Iterable[float], lindir: Iterable[float], point: Iterable[float]
+    linpt: Union[ndarray, Iterable[float]],
+    lindir: Union[ndarray, Iterable[float]],
+    point: Union[ndarray, Iterable[float]],
 ) -> Tuple[ndarray, float]:
     """
     Find the nearest point on a line to a specified point,
@@ -9171,7 +9231,9 @@ def nvc2pl(normal: Union[Iterable[float], Iterable[float]], constant: float) -> 
 
 
 @spice_error_check
-def nvp2pl(normal: Iterable[float], point: Iterable[float]) -> Plane:
+def nvp2pl(
+    normal: Union[ndarray, Iterable[float]], point: Union[ndarray, Iterable[float]]
+) -> Plane:
     """
     Make a plane from a normal vector and a point.
 
@@ -9528,7 +9590,7 @@ def pckw02(
     intlen: float,
     n: int,
     polydg: int,
-    cdata: Iterable[float],
+    cdata: Union[ndarray, Iterable[float]],
     btime: float,
 ) -> None:
     """
@@ -9805,10 +9867,10 @@ def pltexp(
 
 @spice_error_check
 def pltnp(
-    point: Iterable[float],
-    v1: Iterable[float],
-    v2: Iterable[float],
-    v3: Iterable[float],
+    point: Union[ndarray, Iterable[float]],
+    v1: Union[ndarray, Iterable[float]],
+    v2: Union[ndarray, Iterable[float]],
+    v3: Union[ndarray, Iterable[float]],
 ) -> Tuple[ndarray, float]:
     """
     Find the nearest point on a triangular plate to a given point.
@@ -9834,7 +9896,7 @@ def pltnp(
 @spice_error_check
 def pltnrm(
     v1: Iterable[Union[float, float]],
-    v2: Iterable[float],
+    v2: Union[ndarray, Iterable[float]],
     v3: Iterable[Union[float, float]],
 ) -> ndarray:
     """
@@ -9876,7 +9938,9 @@ def pltvol(vrtces: Sequence[Iterable[float]], plates: Sequence[Iterable[int]]) -
 
 
 @spice_error_check
-def polyds(coeffs: Iterable[float], deg: int, nderiv: int, t: int) -> ndarray:
+def polyds(
+    coeffs: Union[ndarray, Iterable[float]], deg: int, nderiv: int, t: int
+) -> ndarray:
     """
     Compute the value of a polynomial and it's first
     n derivatives at the value t.
@@ -10103,7 +10167,7 @@ def qcktrc(tracelen: int = _default_len_out) -> str:
 
 
 @spice_error_check
-def qdq2av(q: ndarray, dq: Iterable[float]) -> ndarray:
+def qdq2av(q: ndarray, dq: Union[ndarray, Iterable[float]]) -> ndarray:
     """
     Derive angular velocity from a unit quaternion and its derivative
     with respect to time.
@@ -10122,7 +10186,9 @@ def qdq2av(q: ndarray, dq: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def qxq(q1: Union[ndarray, Iterable[float]], q2: Iterable[float]) -> ndarray:
+def qxq(
+    q1: Union[ndarray, Iterable[float]], q2: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """
     Multiply two quaternions.
 
@@ -10165,7 +10231,9 @@ def radrec(inrange: float, re: float, dec: float) -> ndarray:
 
 
 @spice_error_check
-def rav2xf(rot: Iterable[Iterable[float]], av: Iterable[float]) -> ndarray:
+def rav2xf(
+    rot: Union[ndarray, Iterable[Iterable[float]]], av: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """
     This routine determines a state transformation matrix
     from a rotation matrix and the angular velocity of the
@@ -10224,7 +10292,7 @@ def rdtext(
 
 
 @spice_error_check
-def reccyl(rectan: Iterable[float]) -> Tuple[float, float, float]:
+def reccyl(rectan: Union[ndarray, Iterable[float]]) -> Tuple[float, float, float]:
     """
     Convert from rectangular to cylindrical coordinates.
 
@@ -10245,7 +10313,9 @@ def reccyl(rectan: Iterable[float]) -> Tuple[float, float, float]:
 
 
 @spice_error_check
-def recgeo(rectan: Iterable[float], re: float, f: float) -> Tuple[float, float, float]:
+def recgeo(
+    rectan: Union[ndarray, Iterable[float]], re: float, f: float
+) -> Tuple[float, float, float]:
     """
     Convert from rectangular coordinates to geodetic coordinates.
 
@@ -10421,7 +10491,7 @@ def removi(item: int, inset: SpiceCell) -> None:
 
 @spice_error_check
 def reordc(
-    iorder: Iterable[int], ndim: int, lenvals: int, array: Iterable[str]
+    iorder: Union[ndarray, Iterable[int]], ndim: int, lenvals: int, array: Iterable[str]
 ) -> Iterable[str]:
     """
     Re-order the elements of an array of character strings
@@ -10444,7 +10514,11 @@ def reordc(
 
 
 @spice_error_check
-def reordd(iorder: Iterable[int], ndim: int, array: Iterable[float]) -> ndarray:
+def reordd(
+    iorder: Union[ndarray, Iterable[int]],
+    ndim: int,
+    array: Union[ndarray, Iterable[float]],
+) -> ndarray:
     """
     Re-order the elements of a double precision array according to
     a given order vector.
@@ -10464,7 +10538,11 @@ def reordd(iorder: Iterable[int], ndim: int, array: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def reordi(iorder: Iterable[int], ndim: int, array: Iterable[int]) -> ndarray:
+def reordi(
+    iorder: Union[ndarray, Iterable[int]],
+    ndim: int,
+    array: Union[ndarray, Iterable[int]],
+) -> ndarray:
     """
     Re-order the elements of an integer array according to
     a given order vector.
@@ -10484,7 +10562,9 @@ def reordi(iorder: Iterable[int], ndim: int, array: Iterable[int]) -> ndarray:
 
 
 @spice_error_check
-def reordl(iorder: Iterable[int], ndim: int, array: Iterable[bool]) -> ndarray:
+def reordl(
+    iorder: Union[ndarray, Iterable[int]], ndim: int, array: Iterable[bool]
+) -> ndarray:
     """
     Re-order the elements of a logical (Boolean) array according to
     a given order vector.
@@ -10787,7 +10867,9 @@ def rquad(a: float, b: float, c: float) -> Tuple[ndarray, ndarray]:
 
 
 @spice_error_check
-def saelgv(vec1: Iterable[float], vec2: Iterable[float]) -> Tuple[ndarray, ndarray]:
+def saelgv(
+    vec1: Union[ndarray, Iterable[float]], vec2: Union[ndarray, Iterable[float]]
+) -> Tuple[ndarray, ndarray]:
     """
     Find semi-axis vectors of an ellipse generated by two arbitrary
     three-dimensional vectors.
@@ -11133,7 +11215,7 @@ def shellc(ndim: int, lenvals: int, array: Iterable[str]) -> Iterable[str]:
 
 
 @spice_error_check
-def shelld(ndim: int, array: Iterable[float]) -> ndarray:
+def shelld(ndim: int, array: Union[ndarray, Iterable[float]]) -> ndarray:
     # Works!, use this as example for "I/O" parameters
     """
     Sort a double precision array using the Shell Sort algorithm.
@@ -11151,7 +11233,7 @@ def shelld(ndim: int, array: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def shelli(ndim: int, array: Iterable[int]) -> ndarray:
+def shelli(ndim: int, array: Union[ndarray, Iterable[int]]) -> ndarray:
     # Works!, use this as example for "I/O" parameters
     """
     Sort an integer array using the Shell Sort algorithm.
@@ -11502,7 +11584,10 @@ def spkaps(
 
 @spice_error_check
 def spk14a(
-    handle: int, ncsets: int, coeffs: Iterable[float], epochs: Iterable[float]
+    handle: int,
+    ncsets: int,
+    coeffs: Union[ndarray, Iterable[float]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Add data to a type 14 SPK segment associated with handle. See
@@ -11616,7 +11701,7 @@ def spkcpo(
     outref: str,
     refloc: str,
     abcorr: str,
-    obspos: Iterable[float],
+    obspos: Union[ndarray, Iterable[float]],
     obsctr: str,
     obsref: str,
 ) -> Tuple[ndarray, float]:
@@ -11667,7 +11752,7 @@ def spkcpo(
 
 @spice_error_check
 def spkcpt(
-    trgpos: Iterable[float],
+    trgpos: Union[ndarray, Iterable[float]],
     trgctr: str,
     trgref: str,
     et: float,
@@ -11728,7 +11813,7 @@ def spkcvo(
     outref: str,
     refloc: str,
     abcorr: str,
-    obssta: Iterable[float],
+    obssta: Union[ndarray, Iterable[float]],
     obsepc: float,
     obsctr: str,
     obsref: str,
@@ -11783,7 +11868,7 @@ def spkcvo(
 
 @spice_error_check
 def spkcvt(
-    trgsta: Iterable[float],
+    trgsta: Union[ndarray, Iterable[float]],
     trgepc: float,
     trgctr: str,
     trgref: str,
@@ -12360,7 +12445,7 @@ def spkw02(
     intlen: float,
     n: int,
     polydg: int,
-    cdata: Iterable[float],
+    cdata: Union[ndarray, Iterable[float]],
     btime: float,
 ) -> None:
     """
@@ -12421,7 +12506,7 @@ def spkw03(
     intlen: float,
     n: int,
     polydg: int,
-    cdata: Iterable[float],
+    cdata: Union[ndarray, Iterable[float]],
     btime: float,
 ) -> None:
     """
@@ -12481,8 +12566,8 @@ def spkw05(
     segid: str,
     gm: float,
     n: int,
-    states: Iterable[Iterable[float]],
-    epochs: Iterable[float],
+    states: Union[ndarray, Iterable[Iterable[float]]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     # see libspice args for solution to array[][N] problem
     """
@@ -12531,7 +12616,7 @@ def spkw08(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epoch1: float,
     step: float,
 ) -> None:
@@ -12593,8 +12678,8 @@ def spkw09(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
-    epochs: Iterable[float],
+    states: Union[ndarray, Iterable[Iterable[float]]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write a type 9 segment to an SPK file.
@@ -12638,10 +12723,10 @@ def spkw10(
     first: float,
     last: float,
     segid: str,
-    consts: Iterable[float],
+    consts: Union[ndarray, Iterable[float]],
     n: int,
-    elems: Iterable[float],
-    epochs: Iterable[float],
+    elems: Union[ndarray, Iterable[float]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write an SPK type 10 segment to the DAF open and attached to
@@ -12688,7 +12773,7 @@ def spkw12(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epoch0: float,
     step: float,
 ) -> None:
@@ -12749,8 +12834,8 @@ def spkw13(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
-    epochs: Iterable[float],
+    states: Union[ndarray, Iterable[Iterable[float]]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write a type 13 segment to an SPK file.
@@ -12800,7 +12885,7 @@ def spkw15(
     p: float,
     ecc: float,
     j2flg: float,
-    pv: Iterable[float],
+    pv: Union[ndarray, Iterable[float]],
     gm: float,
     j2: float,
     radius: float,
@@ -13673,7 +13758,9 @@ def sumai(array: Sequence[int]) -> int:
 
 
 @spice_error_check
-def surfnm(a: float, b: float, c: float, point: Iterable[float]) -> ndarray:
+def surfnm(
+    a: float, b: float, c: float, point: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """
     This routine computes the outward-pointing, unit normal vector
     from a point on the surface of an ellipsoid.
@@ -13731,7 +13818,11 @@ def surfpt(
 @spice_error_check
 @spice_found_exception_thrower
 def surfpv(
-    stvrtx: Iterable[float], stdir: Iterable[float], a: float, b: float, c: float
+    stvrtx: Union[ndarray, Iterable[float]],
+    stdir: Union[ndarray, Iterable[float]],
+    a: float,
+    b: float,
+    c: float,
 ) -> Tuple[ndarray, bool]:
     """
     Find the state (position and velocity) of the surface intercept
@@ -13839,7 +13930,7 @@ def termpt(
     abcorr: str,
     corloc: str,
     obsrvr: str,
-    refvec: Iterable[float],
+    refvec: Union[ndarray, Iterable[float]],
     rolstp: float,
     ncuts: int,
     schstp: float,
@@ -14113,7 +14204,7 @@ def tpictr(
 
 
 @spice_error_check
-def trace(matrix: Iterable[Iterable[float]]) -> float:
+def trace(matrix: Union[ndarray, Iterable[Iterable[float]]]) -> float:
     """
     Return the trace of a 3x3 matrix.
 
@@ -14201,7 +14292,10 @@ def twopi() -> float:
 
 @spice_error_check
 def twovec(
-    axdef: Iterable[float], indexa: int, plndef: Iterable[float], indexp: int
+    axdef: Union[ndarray, Iterable[float]],
+    indexa: int,
+    plndef: Union[ndarray, Iterable[float]],
+    indexp: int,
 ) -> ndarray:
     """
     Find the transformation to the right-handed frame having a
@@ -14505,7 +14599,9 @@ def utc2et(utcstr: str) -> float:
 
 
 @spice_error_check
-def vadd(v1: Iterable[float], v2: Iterable[float]) -> ndarray:
+def vadd(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """Add two 3 dimensional vectors.
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vadd_c.html
 
@@ -14521,7 +14617,9 @@ def vadd(v1: Iterable[float], v2: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def vaddg(v1: Iterable[float], v2: Iterable[float], ndim: int) -> ndarray:
+def vaddg(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]], ndim: int
+) -> ndarray:
     """
     Add two n-dimensional vectors
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vaddg_c.html
@@ -14744,11 +14842,11 @@ def vlcom(
 @spice_error_check
 def vlcom3(
     a: float,
-    v1: Iterable[float],
+    v1: Union[ndarray, Iterable[float]],
     b: float,
-    v2: Iterable[float],
+    v2: Union[ndarray, Iterable[float]],
     c: float,
-    v3: Iterable[float],
+    v3: Union[ndarray, Iterable[float]],
 ) -> ndarray:
     """
     This subroutine computes the vector linear combination
@@ -14910,7 +15008,7 @@ def vperp(a: ndarray, b: ndarray) -> ndarray:
 
 
 @spice_error_check
-def vprjp(vin: Iterable[float], plane: Plane) -> ndarray:
+def vprjp(vin: Union[ndarray, Iterable[float]], plane: Plane) -> ndarray:
     """
     Project a vector onto a specified plane, orthogonally.
 
@@ -14928,7 +15026,9 @@ def vprjp(vin: Iterable[float], plane: Plane) -> ndarray:
 
 @spice_error_check
 @spice_found_exception_thrower
-def vprjpi(vin: Iterable[float], projpl: Plane, invpl: Plane) -> Tuple[ndarray, bool]:
+def vprjpi(
+    vin: Union[ndarray, Iterable[float]], projpl: Plane, invpl: Plane
+) -> Tuple[ndarray, bool]:
     """
     Find the vector in a specified plane that maps to a specified
     vector in another plane under orthogonal projection.
@@ -14968,7 +15068,9 @@ def vproj(a: ndarray, b: ndarray) -> ndarray:
 
 
 @spice_error_check
-def vrel(v1: Iterable[float], v2: Iterable[float]) -> float:
+def vrel(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]]
+) -> float:
     """
     Return the relative difference between two 3-dimensional vectors.
 
@@ -14984,7 +15086,9 @@ def vrel(v1: Iterable[float], v2: Iterable[float]) -> float:
 
 
 @spice_error_check
-def vrelg(v1: Iterable[float], v2: Iterable[float], ndim: int) -> float:
+def vrelg(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]], ndim: int
+) -> float:
     """
     Return the relative difference between two vectors of general dimension.
 
@@ -15158,7 +15262,13 @@ def vtmv(v1: ndarray, matrix: ndarray, v2: ndarray) -> float:
 
 
 @spice_error_check
-def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: int, ncol: int) -> float:
+def vtmvg(
+    v1: ndarray,
+    matrix: ndarray,
+    v2: ndarray,
+    nrow: OptionalInt = None,
+    ncol: OptionalInt = None,
+) -> float:
     """
     Multiply the transpose of a n-dimensional
     column vector a nxm matrix,
@@ -15173,6 +15283,8 @@ def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: int, ncol: int) -> fl
     :param ncol: Number of columns in matrix (number of rows in v2.)
     :return: the result of (v1**t * matrix * v2 )
     """
+    warn_depricated_args(nrow=nrow, ncol=ncol)
+    nrow, ncol = len(v1), len(v2)
     v1 = stypes.to_double_vector(v1)
     matrix = stypes.to_double_matrix(matrix)
     v2 = stypes.to_double_vector(v2)
@@ -15708,7 +15820,7 @@ def xpose(m: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
 
 
 @spice_error_check
-def xpose6(m: Iterable[Iterable[float]]) -> ndarray:
+def xpose6(m: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
     """
     Transpose a 6x6 matrix
 
@@ -15725,7 +15837,9 @@ def xpose6(m: Iterable[Iterable[float]]) -> ndarray:
 
 @spice_error_check
 def xposeg(
-    matrix: Union[ndarray, Iterable[Iterable[float]]], nrow: int, ncol: int
+    matrix: Union[ndarray, Iterable[Iterable[float]]],
+    nrow: OptionalInt = None,
+    ncol: OptionalInt = None,
 ) -> ndarray:
     """
     Transpose a matrix of arbitrary size
@@ -15738,8 +15852,10 @@ def xposeg(
     :param ncol: Number of columns of input matrix
     :return: Transposed matrix
     """
+    warn_depricated_args(nrow=nrow, ncol=ncol)
+    ncol, nrow = len(matrix[0]), len(matrix)
     matrix = stypes.to_double_matrix(matrix)
-    mout = stypes.empty_double_matrix(x=ncol, y=nrow)
+    mout = stypes.empty_double_matrix(x=nrow, y=ncol)
     ncol = ctypes.c_int(ncol)
     nrow = ctypes.c_int(nrow)
     libspice.xposeg_c(matrix, nrow, ncol, mout)

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -5866,7 +5866,7 @@ def test_mtxm():
 def test_mtxmg():
     m1 = np.array([[1.0, 2.0, 3.0, 0.0], [1.0, 1.0, 1.0, 1.0]])
     m2 = np.array([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]])
-    mout = spice.mtxmg(m1, m2, 4, 2, 3)
+    mout = spice.mtxmg(m1, m2)
     expected = np.array(
         [[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [3.0, 6.0, 9.0], [0.0, 0.0, 0.0]]
     )
@@ -5884,7 +5884,7 @@ def test_mtxv():
 def test_mtxvg():
     m1 = np.array([[1.0, 2.0], [1.0, 3.0], [1.0, 4.0]])
     v2 = np.array([1.0, 2.0, 3.0])
-    mout = spice.mtxvg(m1, v2, 2, 3)
+    mout = spice.mtxvg(m1, v2)
     expected = np.array([6.0, 20.0])
     assert np.array_equal(mout, expected)
 
@@ -5902,10 +5902,7 @@ def test_mxm():
 def test_mxmg():
     m1 = [[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]]
     m2 = [[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]]
-    nrow1 = 3
-    ncol1 = 2
-    ncol2 = 3
-    mout = np.array(spice.mxmg(m1, m2, nrow1, ncol1, ncol2))
+    mout = np.array(spice.mxmg(m1, m2))
     m1 = np.array(m1)
     m2 = np.array(m2)
     mout2 = np.dot(m1, m2)
@@ -5935,6 +5932,14 @@ def test_mxv():
 
 
 def test_mxvg():
+    m1 = np.array([[1.0, 1.0, 1.0], [2.0, 3.0, 4.0]])
+    v2 = np.array([1.0, 2.0, 3.0])
+    mout = spice.mxvg(m1, v2)
+    expected = np.array([6.0, 20.0])
+    assert np.array_equal(mout, expected)
+    
+
+def test_mxvg_old_api():
     m1 = np.array([[1.0, 1.0, 1.0], [2.0, 3.0, 4.0]])
     v2 = np.array([1.0, 2.0, 3.0])
     mout = spice.mxvg(m1, v2, 2, 3)
@@ -10193,7 +10198,7 @@ def test_vtmvg():
     v1 = np.array([1.0, 2.0, 3.0])
     v2 = np.array([1.0, 2.0])
     matrix = np.array([[2.0, 0.0], [1.0, 2.0], [1.0, 1.0]])
-    assert spice.vtmvg(v1, matrix, v2, 3, 2) == 21.0
+    assert spice.vtmvg(v1, matrix, v2) == 21.0
 
 
 def test_vupack():
@@ -10538,12 +10543,14 @@ def test_xpose():
 def test_xposeg():
     m1 = [[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 6.0, 0.0]]
     npt.assert_array_almost_equal(
-        spice.xposeg(m1, 3, 3), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
+        spice.xposeg(m1), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
     )
     npt.assert_array_almost_equal(
-        spice.xposeg(np.array(m1), 3, 3),
+        spice.xposeg(np.array(m1)),
         [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]],
     )
+    m2 = np.random.rand(3, 4)
+    npt.assert_array_almost_equal(spice.xposeg(m2), m2.T)
 
 
 def test_zzdynrot():


### PR DESCRIPTION
* Simplifying functions with ncol/nrow params, added deprecation warning for these functions if users specify parameters

Some of the early functions I implemented for SpiceyPy were the linear
algebra functions which aren't critical. In those I left some of the
argument row/col dimension arguments which SpiceyPy can figure out for
the user.